### PR TITLE
Add a clarification inside the example webpage.

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -3,7 +3,13 @@
 <head>
   <meta charset="UTF-8">
   <title>Feather</title>
+  <!--
+       In order to build the feather minimized js run
+       $ npm run build
+       in the cloned repository, or use the already built package available on unpkg.com.
+  -->
   <script src="../dist/feather.min.js"></script>
+  <!-- <script src="https://unpkg.com/feather-icons/dist/feather.min.js"></script> -->
 </head>
 <body>
 


### PR DESCRIPTION
As discussed in issue #176, the package has to be built using
$ npm run build
or
$ npm run all
before being able to use it.