### PR TITLE
Update list.svg to allow for css overwriting

### DIFF
--- a/icons/list.svg
+++ b/icons/list.svg
@@ -1,5 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2">
     <line x1="8" y1="6" x2="21" y2="6"/>
+    <line x1="8" y1="12" x2="21" y2="12"/>
     <line x1="8" y1="18" x2="21" y2="18"/>
     <line x1="3" y1="6" x2="3" y2="6"/>
     <line x1="3" y1="12" x2="3" y2="12"/>

--- a/icons/list.svg
+++ b/icons/list.svg
@@ -1,8 +1,7 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-    <line x1="8" y1="6" x2="21" y2="6" fill="none" stroke="#000" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2"/>
-    <line x1="8" y1="12" x2="21" y2="12" fill="none" stroke="#000" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2"/>
-    <line x1="8" y1="18" x2="21" y2="18" fill="none" stroke="#000" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2"/>
-    <line x1="3" y1="6" x2="3" y2="6" fill="none" stroke="#000" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2"/>
-    <line x1="3" y1="12" x2="3" y2="12" fill="none" stroke="#000" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2"/>
-    <line x1="3" y1="18" x2="3" y2="18" fill="none" stroke="#000" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2">
+    <line x1="8" y1="6" x2="21" y2="6"/>
+    <line x1="8" y1="18" x2="21" y2="18"/>
+    <line x1="3" y1="6" x2="3" y2="6"/>
+    <line x1="3" y1="12" x2="3" y2="12"/>
+    <line x1="3" y1="18" x2="3" y2="18"/>
 </svg>


### PR DESCRIPTION
The stroke and other attributes being directly set on the lines of this icon avoid overwriting them with css.
While most of the other icons have set these attributes on the svg parent tag, which allow for overwriting them.
This fix simply move the attributes from the lines to the svg parent tag.