### PR TITLE
fix help-circle.svg

### DIFF
--- a/icons/help-circle.svg
+++ b/icons/help-circle.svg
@@ -11,5 +11,5 @@
 >
   <circle cx="12" cy="12" r="10" />
   <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3" />
-  <line x1="12" y1="17" x2="12" y2="17" />
+  <circle cx="12" cy="17" r="1" fill="currentColor" stroke="none" />
 </svg>


### PR DESCRIPTION
Some renderers ignore zero-length lines. Replaced with circle.