### PR TITLE
Feature: Append and prepend svg to element

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ A SVG Sprite is also provided, which can be used as following:
 ```html
 <svg class="feather feather-[iconName]"
   width="24"
-  height="24"  
+  height="24"
   fill="none"
   stroke="currentColor"
   stroke-width="2"
@@ -187,12 +187,12 @@ Where `iconName` is the name of the icon you want to display.
 Same result but using a CSS class:
 ```css
 .feather {
-  width: 24px; 
-  height: 24px; 
-  stroke: currentColor; 
-  stroke-width: 2; 
-  stroke-linecap: round; 
-  stroke-linejoin: round; 
+  width: 24px;
+  height: 24px;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
   fill: none;
 }
 ```
@@ -321,6 +321,74 @@ All attributes on the placeholder element (i.e. `<i>`) will be copied to the `<s
 ```
 
 [View Source](https://github.com/colebemis/feather/blob/master/src/replace.js)
+
+---
+
+### `feather.append([attrs])`
+
+Appends the svgs to the element, instead of replacing the element.
+_changes the `data-feather-append` to `data-feather-appended` to prevent prepending multiple svgs_
+
+#### Parameters
+
+| Name       | Type   | Description |
+| ---------- | ------ | ----------- |
+| `attrs` (optional)  | Object | Key-value pairs in the `attrs` object will be mapped to HTML attributes on the `<svg>` tag (e.g. `{ foo: 'bar' }` maps to `foo="bar"`). All default attributes on the `<svg>` tag can be overridden with the `attrs` object. |
+
+#### Usage
+
+> **Note:** `feather.append()` only works in a browser environment.
+
+Simple usage:
+```html
+<i data-feather-append="circle"></i>
+<!--
+<i> will result in:
+<i data-feather-appended="circle">
+  <svg class="feather feather-circle" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"></circle></svg>
+</i>
+-->
+
+<script>
+  feather.append()
+</script>
+```
+
+[View Source](https://github.com/colebemis/feather/blob/master/src/append.js)
+
+---
+
+### `feather.prepend([attrs])`
+
+Prepends the svgs to the element, instead of replacing the element.
+_changes the `data-feather-prepend` to `data-feather-prepended` to prevent prepending multiple svgs_
+
+#### Parameters
+
+| Name       | Type   | Description |
+| ---------- | ------ | ----------- |
+| `attrs` (optional)  | Object | Key-value pairs in the `attrs` object will be mapped to HTML attributes on the `<svg>` tag (e.g. `{ foo: 'bar' }` maps to `foo="bar"`). All default attributes on the `<svg>` tag can be overridden with the `attrs` object. |
+
+#### Usage
+
+> **Note:** `feather.prepend()` only works in a browser environment.
+
+Simple usage:
+```html
+<i data-feather-prepend="circle"></i>
+<!--
+<i> will result in:
+<i data-feather-prepended="circle">
+  <svg class="feather feather-circle" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"></circle></svg>
+</i>
+-->
+
+<script>
+  feather.prepend()
+</script>
+```
+
+[View Source](https://github.com/colebemis/feather/blob/master/src/append.js)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ A SVG Sprite is also provided, which can be used as following:
 ```html
 <svg class="feather feather-[iconName]"
   width="24"
-  height="24"
+  height="24"  
   fill="none"
   stroke="currentColor"
   stroke-width="2"
@@ -187,12 +187,12 @@ Where `iconName` is the name of the icon you want to display.
 Same result but using a CSS class:
 ```css
 .feather {
-  width: 24px;
-  height: 24px;
-  stroke: currentColor;
-  stroke-width: 2;
-  stroke-linecap: round;
-  stroke-linejoin: round;
+  width: 24px; 
+  height: 24px; 
+  stroke: currentColor; 
+  stroke-width: 2; 
+  stroke-linecap: round; 
+  stroke-linejoin: round; 
   fill: none;
 }
 ```

--- a/src/append.js
+++ b/src/append.js
@@ -1,0 +1,59 @@
+/* eslint-env browser */
+import icons from './icons';
+
+const attributeSeletor = 'data-feather-append';
+
+/**
+ * Replace all HTML elements that have a `data-feather` attribute with SVG markup
+ * corresponding to the element's `data-feather` attribute value.
+ * @param {Object} attrs
+ */
+function append(attrs = {}) {
+  if (typeof document === 'undefined') {
+    throw new Error('`feather.append()` only works in a browser environment.');
+  }
+
+  const elementsToReplace = document.querySelectorAll(`[${attributeSeletor}]`);
+
+  Array.from(elementsToReplace).forEach(element =>
+    appendElement(element, attrs),
+  );
+}
+
+/**
+ * Replace a single HTML element with SVG markup
+ * corresponding to the element's `data-feather` attribute value.
+ * @param {HTMLElement} element
+ * @param {Object} attrs
+ */
+function appendElement(element, attrs = {}) {
+  const elementAttrs = getAttrs(element);
+  const name = elementAttrs[attributeSeletor];
+  delete elementAttrs[attributeSeletor];
+
+  element.removeAttribute(attributeSeletor);
+  element.setAttribute(`${attributeSeletor}ed`, name);
+
+  const svgString = icons[name].toSvg(attrs);
+  const svgDocument = new DOMParser().parseFromString(
+    svgString,
+    'image/svg+xml',
+  );
+  const svgElement = svgDocument.querySelector('svg');
+
+  element.appendChild(svgElement);
+}
+
+/**
+ * Get the attributes of an HTML element.
+ * @param {HTMLElement} element
+ * @returns {Object}
+ */
+function getAttrs(element) {
+  return Array.from(element.attributes).reduce((attrs, attr) => {
+    attrs[attr.name] = attr.value;
+    return attrs;
+  }, {});
+}
+
+export default append;

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,7 @@
 import icons from './icons';
 import toSvg from './to-svg';
 import replace from './replace';
+import append from './append';
+import prepend from './prepend';
 
-module.exports = { icons, toSvg, replace };
+module.exports = { icons, toSvg, replace, append, prepend };

--- a/src/prepend.js
+++ b/src/prepend.js
@@ -1,0 +1,63 @@
+/* eslint-env browser */
+import icons from './icons';
+
+const attributeSeletor = 'data-feather-prepend';
+
+/**
+ * Replace all HTML elements that have a `data-feather` attribute with SVG markup
+ * corresponding to the element's `data-feather` attribute value.
+ * @param {Object} attrs
+ */
+function prepend(attrs = {}) {
+  if (typeof document === 'undefined') {
+    throw new Error('`feather.prepend()` only works in a browser environment.');
+  }
+
+  const elementsToReplace = document.querySelectorAll(`[${attributeSeletor}]`);
+
+  Array.from(elementsToReplace).forEach(element =>
+    prependElement(element, attrs),
+  );
+}
+
+/**
+ * Replace a single HTML element with SVG markup
+ * corresponding to the element's `data-feather` attribute value.
+ * @param {HTMLElement} element
+ * @param {Object} attrs
+ */
+function prependElement(element, attrs = {}) {
+  const elementAttrs = getAttrs(element);
+  const name = elementAttrs[attributeSeletor];
+  delete elementAttrs[attributeSeletor];
+
+  element.removeAttribute(attributeSeletor);
+  element.setAttribute(`${attributeSeletor}ed`, name);
+
+  const svgString = icons[name].toSvg(attrs);
+  const svgDocument = new DOMParser().parseFromString(
+    svgString,
+    'image/svg+xml',
+  );
+  const svgElement = svgDocument.querySelector('svg');
+
+  if (element.firstChild) {
+    element.insertBefore(svgElement, element.firstChild);
+  } else {
+    element.appendChild(svgElement);
+  }
+}
+
+/**
+ * Get the attributes of an HTML element.
+ * @param {HTMLElement} element
+ * @returns {Object}
+ */
+function getAttrs(element) {
+  return Array.from(element.attributes).reduce((attrs, attr) => {
+    attrs[attr.name] = attr.value;
+    return attrs;
+  }, {});
+}
+
+export default prepend;


### PR DESCRIPTION
This PR includes two new methods, `feather.append` and `feather.prepend`. Their intention is to add more flexibility when developing generic styles and components.

An example of where this would be useful will be when adding icons to a series of generic button styles. In the example below, the button has no clue there's an svg inside and the positioning the svg would require adding an additional generic button class. _A side note would be the additional button class would have no clue when the svg is loaded and injected._
```html
<!-- before -->
<button class="button-green">
    Read more below
    <i data-feather="chevron-down"></i>
</button>

<!-- after -->
<button class="button-green">
    Read more below
    <svg>...</svg>
</button>
```

Below theres an example of the use of `append`. Note the attribute changes from `append` to `appended` to indicate the svg is loaded and inserted. _The same would happen with `prepend`_

```html
<!-- before -->
<button class="button-green" data-feather-append="chevron-down">
    Read more below
</button>

<!-- after -->
<button class="button-green" data-feather-appended="chevron-down">
    Read more below
    <svg>...</svg>
</button>
```
The above example allows the generic button style to take the icon into consideration.

```scss
.button-green {
    ...
    &[data-feather-append] {
        padding-right: 40px;

        svg {
            position: absolute;
            right: 10px;
        }
    }
}
```
