### PR TITLE
Fix UMD build for node

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,7 +8,7 @@ module.exports = {
     library: 'feather',
     // Prevents webpack from referencing `window` in the UMD build
     // Source: https://git.io/vppgU
-    globalObject: 'typeof self !== \'undefined\' ? self : this',
+    globalObject: "typeof self !== 'undefined' ? self : this",
   },
   devtool: 'source-map',
   module: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,6 +6,9 @@ module.exports = {
     path: path.resolve(__dirname, 'dist'),
     libraryTarget: 'umd',
     library: 'feather',
+    // Prevents webpack from referencing `window` in the UMD build
+    // Source: https://git.io/vppgU
+    globalObject: 'typeof self !== \'undefined\' ? self : this',
   },
   devtool: 'source-map',
   module: {


### PR DESCRIPTION
Prevents webpack from referencing `window` in the UMD build which was causing an error in node.

This pull request patches a known issue in webpack 4: https://github.com/webpack/webpack/issues/6522.