### PR TITLE
Add tags for "search" icon

### DIFF
--- a/src/tags.json
+++ b/src/tags.json
@@ -114,6 +114,7 @@
   "rewind": ["music"],
   "rss": ["feed", "subscribe"],
   "save": ["floppy disk"],
+  "search": ["find", "magnifier", "magnifying glass"],
   "send": ["message", "mail", "paper airplane"],
   "settings": ["cog", "edit", "gear", "preferences"],
   "shield": ["security"],


### PR DESCRIPTION
It took me a minute to find the `search` icon on [feathericons.com](https://feathericons.com); this should make it easier