### PR TITLE
Feature: adding mouse pointer to library

### DIFF
--- a/icons/mouse-pointer.svg
+++ b/icons/mouse-pointer.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M3 3l7.07 16.97 2.51-7.39 7.39-2.51L3 3z" />
+  <path d="M13 13l6 6" />
+</svg>

--- a/src/tags.json
+++ b/src/tags.json
@@ -95,6 +95,7 @@
   "moon": ["dark", "night"],
   "more-horizontal": ["ellipsis"],
   "more-vertical": ["ellipsis"],
+  "mouse-pointer": ["mouse", "pointer", "arrow", "cursor"],
   "move": ["arrows"],
   "navigation": ["location", "travel"],
   "navigation-2": ["location", "travel"],


### PR DESCRIPTION
Adding a mouse pointer icon requested in #507. This uses the more narrow cursor arrow but maintains the 45° angle seen in other icons. Example in image below: 

<img width="113" alt="screenshot 2019-01-27 22 35 46" src="https://user-images.githubusercontent.com/10384315/51818461-e6d09400-2283-11e9-8a17-4d8876c0a92b.png">
