### PR TITLE
feat: Add column icon

### DIFF
--- a/icons/columns.svg
+++ b/icons/columns.svg
@@ -1,0 +1,13 @@
+<svg
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  xmlns="http://www.w3.org/2000/svg"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M12 3h7a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-7m0-18H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h7m0-18v18" />
+</svg>


### PR DESCRIPTION
add a column icon for split screen layouts.  approved by @colebemis closes: #565 

<img width="358" alt="Screenshot 2019-03-29 18 18 16" src="https://user-images.githubusercontent.com/9214195/55265514-0b7ac500-524f-11e9-84f8-4edf666815e1.png">
