### PR TITLE
feat: Add `gamepad` icon

### DIFF
--- a/icons/gamepad.svg
+++ b/icons/gamepad.svg
@@ -1,0 +1,17 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M21 6H3a2 2 0 0 0-2 2v8a2 2 0 0 0 2 2h18a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2z" />
+  <path d="M7 14v-4" />
+  <path d="M5 12h4" />
+  <path d="M16 13h.01" />
+  <path d="M19 11h.01" />
+</svg>


### PR DESCRIPTION
Closes #469. In case you want to also check the duplicates, #469 is a duplicate of #120 that already has a PR attached to it (#134). Some things to mention:

1. 2x2 buttons are lines with .01 length like in #728.
2. Since the icon’s shape is narrow, I had to stretch it into the “safe zone” to preserve the optical volume.

In general, gamepads have shapes that are too complex for 24x24 canvases. I think that Google made a good choice by picking the Nintendo Entertainment System controller for Material icons, because not only it’s an iconic object, it’s simple enough to be replicated as an icon, so I did the same for Feather.