### PR TITLE
feat: Add paint icon

### DIFF
--- a/icons/paint.svg
+++ b/icons/paint.svg
@@ -1,0 +1,22 @@
+<svg
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  xmlns="http://www.w3.org/2000/svg"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <g clip-path="url(#a)">
+    <path d="M10.563 5.09l8.827 8.828-7.413 7.413a2 2 0 0 1-2.829 0L3.15 15.332a2 2 0 0 1 0-2.829l7.414-7.413z" />
+    <path d="M10.681 13.944V3.126c-.54-1.041-2.366-1.488-3.588 0v5.261" />
+    <path d="M20.601 21.657v-7.062a2 2 0 0 0-.64-1.466l-2.077-1.926" />
+  </g>
+  <defs>
+    <clipPath id="a">
+      <rect width="24" height="24" />
+    </clipPath>
+  </defs>
+</svg>


### PR DESCRIPTION
Closes #786.

`npm install` and `npm run all` worked, but I couldn't get the pre-commit hook working. Maybe it's because I'm using Windows Subsystem for Linux?
```
dawn@Alar:/mnt/d/repositories/feather$ git commit -m "add paint icon"
husky > npm run -s precommit (node v13.1.0)

 ↓ Running tasks for *.js [skipped]
   → No staged files match *.js
husky > npm run -s commitmsg (node v13.1.0)

/mnt/d/repositories/feather/node_modules/@commitlint/cli/lib/help.js:34
                return `${fs.join(',')}${' '.repeat(4 + longest - length)}${desc}${ds}`;
                                             ^

RangeError: Invalid count value
    at String.repeat (<anonymous>)
    at /mnt/d/repositories/feather/node_modules/@commitlint/cli/lib/help.js:34:32
    at Array.map (<anonymous>)
    at module.exports (/mnt/d/repositories/feather/node_modules/@commitlint/cli/lib/help.js:23:15)
    at Object.<anonymous> (/mnt/d/repositories/feather/node_modules/@commitlint/cli/lib/cli.js:58:76)
    at Module._compile (internal/modules/cjs/loader.js:1063:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1103:10)
    at Module.load (internal/modules/cjs/loader.js:914:32)
    at Function.Module._load (internal/modules/cjs/loader.js:822:14)
    at Function.Module.runMain (internal/modules/cjs/loader.js:1143:12)
```