### PR TITLE
Add mouse-text icon

### DIFF
--- a/icons/mouse-text.svg
+++ b/icons/mouse-text.svg
@@ -1,0 +1,13 @@
+<svg
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  xmlns="http://www.w3.org/2000/svg"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M7 21h2c1.5 0 3-1.5 3-3m0 0V6m0 12c0 1.5 1.5 3 3 3h2M12 6c0-1.5-1.5-3-3-3H7m5 3c0-1.5 1.5-3 3-3h2" />
+</svg>


### PR DESCRIPTION
Closes #508 

This PR is for my version of a mouse cursor when hovering over text.

Here is a scaled up view of it:
![image](https://user-images.githubusercontent.com/9214195/80532706-863e7400-896a-11ea-9605-d8cf10a44fe7.png)

And here is a real size version:

![mouse-text](https://user-images.githubusercontent.com/9214195/80532799-aa9a5080-896a-11ea-82df-8ddb0ddc8a46.png)

I believe it follows all of the guidelines from this post - https://github.com/feathericons/feather/issues/171#issuecomment-455356985

If there is anything that should be changed, please let me know!  I will change anything as needed asap.