### PR TITLE
Fix return tag on processSvg

### DIFF
--- a/bin/process-svg.js
+++ b/bin/process-svg.js
@@ -7,7 +7,7 @@ import DEFAULT_ATTRS from '../src/default-attrs.json';
 /**
  * Process SVG string.
  * @param {string} svg - An SVG string.
- * @param {Promise<string>}
+ * @returns {Promise<string>}
  */
 function processSvg(svg) {
   return (


### PR DESCRIPTION
The `@returns` line for the `processSvg` function was using `@param`