### PR TITLE
Replace "xlink:href" with "href"

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Include an icon on your page with the following markup:
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <use xlink:href="path/to/feather-sprite.svg#circle"/>
+  <use href="path/to/feather-sprite.svg#circle"/>
 </svg>
 ```
 
@@ -216,7 +216,7 @@ However, this markup can be simplified using a simple CSS class to avoid repetit
 
 ```html
 <svg class="feather">
-  <use xlink:href="path/to/dist/feather-sprite.svg#circle"/>
+  <use href="path/to/dist/feather-sprite.svg#circle"/>
 </svg>
 ```
 ### Figma


### PR DESCRIPTION
As mentioned in this [documentation](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/xlink:href), `xlink:href` attribute is now deprecated.

> SVG 2 removed the need for the `xlink` namespace, so instead of `xlink:href` you should use `href`.