### PR TITLE
Update tags.json

### DIFF
--- a/src/tags.json
+++ b/src/tags.json
@@ -104,7 +104,7 @@
   "key": ["password", "login", "authentication", "secure"],
   "layers": ["stack"],
   "layout": ["window", "webpage"],
-  "life-bouy": ["help", "life ring", "support"],
+  "life-buoy": ["help", "life ring", "support"],
   "link": ["chain", "url"],
   "link-2": ["chain", "url"],
   "linkedin": ["logo", "social media"],


### PR DESCRIPTION
Fix for a name inconsistency. `react-feather` refers to LifeBuoy whereas in this file associated tags are `life-bouy` not `life-buoy`.