### PR TITLE
Replace TravisCI with GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,6 @@
 name: CI
 
-on:
-  push:
+on: push
 
 jobs:
   build:
@@ -15,3 +14,10 @@ jobs:
         cache: 'npm'
     - run: npm ci
     - run: npm run all
+  release:
+    runs-on: ubuntu-latest
+    needs: build
+    # if: github.ref_name == 'master'
+    steps:
+    - run: ls
+    # - run: npx semantic-release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,6 @@ jobs:
         cache: 'npm'
     - run: npm ci
     - run: npm run all
-    - run: ls
-  release:
-    runs-on: ubuntu-latest
-    needs: build
-    # if: github.ref_name == 'master'
-    steps:
-    - run: ls
-    # - run: npx semantic-release
+    - name: Release
+      if: github.ref_name == 'master'
+      run: npx semantic-release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+# This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: CI
+
+on:
+  push:
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [12.x, 14.x, 16.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: 'npm'
+    - run: npm ci
+    - run: npm run all

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
         cache: 'npm'
     - run: npm ci
     - run: npm run all
+    - run: ls
   release:
     runs-on: ubuntu-latest
     needs: build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,3 @@
-# This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
-
 name: CI
 
 on:
@@ -8,20 +5,13 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        node-version: [12.x, 14.x, 16.x]
-        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
-
     steps:
     - uses: actions/checkout@v3
-    - name: Use Node.js ${{ matrix.node-version }}
+    - name: Use Node.js 16.x
       uses: actions/setup-node@v3
       with:
-        node-version: ${{ matrix.node-version }}
+        node-version: 16.x
         cache: 'npm'
     - run: npm ci
     - run: npm run all


### PR DESCRIPTION
Moving CI into GitHub Actions because travis-ci.org stopped running builds:

![CleanShot 2022-03-29 at 15 45 28](https://user-images.githubusercontent.com/4608155/160719041-e4721466-22be-4aaa-ac0b-231c71655049.png)
