### PR TITLE
Added new vue3 support link

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,7 +394,7 @@ Caught a mistake or want to contribute to the documentation? [Edit this page on 
  - [elm-feather](https://github.com/1602/elm-feather) - Feather icons for Elm applications
  - [react-feather](https://github.com/carmelopullara/react-feather) - Feather icons as React components
  - [sketch-feather](https://github.com/odmln/sketch-feather) - Feather icons as a Sketch library
- - [vue-feather-icons](https://github.com/egoist/vue-feather-icons) - Feather icons as Vue components
+ - [vue-feather-icons](https://github.com/egoist/vue-feather-icons)/[vue3-feather-icons](https://github.com/lukeJEdwards/vue3-feather-icon) - Feather icons as Vue components
  - [php-feather](https://github.com/Pixelrobin/php-feather) - Feather icons as a PHP Library
  - [wp-php-feather](https://github.com/reatlat/wp-php-feather) - Feather icons as a WordPress template tag
  - [django-feather](https://pypi.org/project/django-feather/) - Feather icons as Django Template Tag


### PR DESCRIPTION
vue-feather-icons hasn't been updated to vue3 and is no longer being maintained as the last update was 2 years ago