### PR TITLE
fix stacking context in award.svg

### DIFF
--- a/icons/award.svg
+++ b/icons/award.svg
@@ -9,6 +9,6 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <circle cx="12" cy="8" r="7" />
   <polyline points="8.21 13.89 7 23 12 20 17 23 15.79 13.88" />
+  <circle cx="12" cy="8" r="7" />
 </svg>


### PR DESCRIPTION
currently the circle renders under the polyline, making it tricky to apply both a fill and stroke to the svg as the polyline fill cuts off the circle stroke. this PR would just swap the stacking context of the polyline and circle.

credit @kellykavousi for catching this 