### PR TITLE
Warn about incorrect icon name and handle gracefully

### DIFF
--- a/.changeset/tough-balloons-breathe.md
+++ b/.changeset/tough-balloons-breathe.md
@@ -1,0 +1,5 @@
+---
+'feather-icons': patch
+---
+
+Feather no longer breaks when trying to replace an icon using an invalid name

--- a/src/replace.js
+++ b/src/replace.js
@@ -31,6 +31,11 @@ function replaceElement(element, attrs = {}) {
   const name = elementAttrs['data-feather'];
   delete elementAttrs['data-feather'];
 
+  if (icons[name] === undefined) {
+    console.warn(`feather: '${name}' is not a valid icon`);
+    return;
+  }
+
   const svgString = icons[name].toSvg({
     ...attrs,
     ...elementAttrs,


### PR DESCRIPTION
Was running into bugs in my company's project which uses Feather. I had added an icon with the incorrect name `add` somewhere in our codebase, and it was causing `feather.replace()` to completely break and not replace **any** icons.

This PR will make it warn if you use the incorrect name and then just simply not try to replace it. This prevents the error from occurring.

Related to #443 

![image](https://github.com/feathericons/feather/assets/70014062/239a4ab0-f256-4c0d-bbbf-4e2c2ec0c151)
